### PR TITLE
Add plaintext email templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,7 +235,7 @@ DEFAULTS = {
 
     # URL Prefix for Authentication Endpoints
     'PASSWORDLESS_AUTH_PREFIX': 'auth/',
-    
+
     #  URL Prefix for Verification Endpoints
     'PASSWORDLESS_VERIFY_PREFIX': 'auth/verify/',
 
@@ -265,7 +265,7 @@ DEFAULTS = {
     'PASSWORDLESS_EMAIL_SUBJECT': "Your Login Token",
 
     # A plaintext email message overridden by the html message. Takes one string.
-    'PASSWORDLESS_EMAIL_PLAINTEXT_MESSAGE': "Enter this token to sign in: %s",
+    'PASSWORDLESS_EMAIL_PLAINTEXT_TEMPLATE_NAME': "passwordless_default_token_email.txt",
 
     # The email template name.
     'PASSWORDLESS_EMAIL_TOKEN_HTML_TEMPLATE_NAME': "passwordless_default_token_email.html",
@@ -289,7 +289,7 @@ DEFAULTS = {
     'PASSWORDLESS_EMAIL_VERIFICATION_SUBJECT': "Your Verification Token",
 
     # A plaintext verification email message overridden by the html message. Takes one string.
-    'PASSWORDLESS_EMAIL_VERIFICATION_PLAINTEXT_MESSAGE': "Enter this verification code: %s",
+    'PASSWORDLESS_EMAIL_VERIFICATION_PLAINTEXT_TEMPLATE_NAME': "passwordless_default_verification_token_email.txt",
 
     # The verification email template name.
     'PASSWORDLESS_EMAIL_VERIFICATION_TOKEN_HTML_TEMPLATE_NAME': "passwordless_default_verification_token_email.html",
@@ -306,7 +306,7 @@ DEFAULTS = {
     # the token itself, the second is a boolean value representating whether
     # the token was newly created.
     'PASSWORDLESS_AUTH_TOKEN_CREATOR': 'drfpasswordless.utils.create_authentication_token',
-    
+
     # What function is called to construct a serializer for drf tokens when
     # exchanging a passwordless token for a real user auth token.
     'PASSWORDLESS_AUTH_TOKEN_SERIALIZER': 'drfpasswordless.serializers.TokenResponseSerializer',
@@ -316,7 +316,7 @@ DEFAULTS = {
 
     # configurable function for sending email
     'PASSWORDLESS_EMAIL_CALLBACK': 'drfpasswordless.utils.send_email_with_callback_token',
-    
+
     # configurable function for sending sms
     'PASSWORDLESS_SMS_CALLBACK': 'drfpasswordless.utils.send_sms_with_callback_token',
 

--- a/drfpasswordless/settings.py
+++ b/drfpasswordless/settings.py
@@ -42,7 +42,7 @@ DEFAULTS = {
     'PASSWORDLESS_EMAIL_SUBJECT': "Your Login Token",
 
     # A plaintext email message overridden by the html message. Takes one string.
-    'PASSWORDLESS_EMAIL_PLAINTEXT_MESSAGE': "Enter this token to sign in: %s",
+    'PASSWORDLESS_EMAIL_PLAINTEXT_TEMPLATE_NAME': "passwordless_default_token_email.txt",
 
     # The email template name.
     'PASSWORDLESS_EMAIL_TOKEN_HTML_TEMPLATE_NAME': "passwordless_default_token_email.html",
@@ -66,7 +66,7 @@ DEFAULTS = {
     'PASSWORDLESS_EMAIL_VERIFICATION_SUBJECT': "Your Verification Token",
 
     # A plaintext verification email message overridden by the html message. Takes one string.
-    'PASSWORDLESS_EMAIL_VERIFICATION_PLAINTEXT_MESSAGE': "Enter this verification code: %s",
+    'PASSWORDLESS_EMAIL_VERIFICATION_PLAINTEXT_TEMPLATE_NAME': "passwordless_default_verification_token_email.txt",
 
     # The verification email template name.
     'PASSWORDLESS_EMAIL_VERIFICATION_TOKEN_HTML_TEMPLATE_NAME': "passwordless_default_verification_token_email.html",

--- a/drfpasswordless/signals.py
+++ b/drfpasswordless/signals.py
@@ -37,14 +37,14 @@ def check_unique_tokens(sender, instance, **kwargs):
         if isinstance(instance, CallbackToken):
             unique = False
             tries = 0
-                
+
             if CallbackToken.objects.filter(key=instance.key, is_active=True).exists():
                 # Try N(default=3) times before giving up.
                 while tries < api_settings.PASSWORDLESS_TOKEN_GENERATION_ATTEMPTS:
                     tries = tries + 1
                     new_key = generate_numeric_token()
                     instance.key = new_key
-                
+
                     if not CallbackToken.objects.filter(key=instance.key, is_active=True).exists():
                         # Leave the loop if we found a valid token that doesn't exist yet.
                         unique = True
@@ -57,7 +57,7 @@ def check_unique_tokens(sender, instance, **kwargs):
                 # A unique value was found immediately.
                 pass
 
-        
+
     else:
         # save is called on an already existing token to update it. Such as invalidating it.
         # in that case there is no need to check for the key. This way we both avoid an unneccessary db hit
@@ -97,7 +97,7 @@ def update_alias_verification(sender, instance, **kwargs):
                         setattr(instance, email_verified_field, False)
                         if api_settings.PASSWORDLESS_AUTO_SEND_VERIFICATION_TOKEN is True:
                             email_subject = api_settings.PASSWORDLESS_EMAIL_VERIFICATION_SUBJECT
-                            email_plaintext = api_settings.PASSWORDLESS_EMAIL_VERIFICATION_PLAINTEXT_MESSAGE
+                            email_plaintext = api_settings.PASSWORDLESS_EMAIL_VERIFICATION_PLAINTEXT_TEMPLATE_NAME
                             email_html = api_settings.PASSWORDLESS_EMAIL_VERIFICATION_TOKEN_HTML_TEMPLATE_NAME
                             message_payload = {'email_subject': email_subject,
                                                'email_plaintext': email_plaintext,

--- a/drfpasswordless/templates/passwordless_default_token_email.txt
+++ b/drfpasswordless/templates/passwordless_default_token_email.txt
@@ -1,0 +1,1 @@
+Use this code to log in: {{ callback_token }}

--- a/drfpasswordless/templates/passwordless_default_verification_token_email.txt
+++ b/drfpasswordless/templates/passwordless_default_verification_token_email.txt
@@ -1,0 +1,1 @@
+Use this verification code: {{ callback_token }}

--- a/drfpasswordless/views.py
+++ b/drfpasswordless/views.py
@@ -1,8 +1,9 @@
 import logging
 from django.utils.module_loading import import_string
 from rest_framework import parsers, renderers, status
+
 from rest_framework.response import Response
-from rest_framework.permissions import AllowAny, IsAuthenticated 
+from rest_framework.permissions import AllowAny, IsAuthenticated
 from rest_framework.views import APIView
 from drfpasswordless.models import CallbackToken
 from drfpasswordless.settings import api_settings
@@ -77,7 +78,7 @@ class ObtainEmailCallbackToken(AbstractBaseObtainCallbackToken):
     token_type = CallbackToken.TOKEN_TYPE_AUTH
 
     email_subject = api_settings.PASSWORDLESS_EMAIL_SUBJECT
-    email_plaintext = api_settings.PASSWORDLESS_EMAIL_PLAINTEXT_MESSAGE
+    email_plaintext = api_settings.PASSWORDLESS_EMAIL_PLAINTEXT_TEMPLATE_NAME
     email_html = api_settings.PASSWORDLESS_EMAIL_TOKEN_HTML_TEMPLATE_NAME
     message_payload = {"email_subject": email_subject,
                        "email_plaintext": email_plaintext,
@@ -107,7 +108,7 @@ class ObtainEmailVerificationCallbackToken(AbstractBaseObtainCallbackToken):
     token_type = CallbackToken.TOKEN_TYPE_VERIFY
 
     email_subject = api_settings.PASSWORDLESS_EMAIL_VERIFICATION_SUBJECT
-    email_plaintext = api_settings.PASSWORDLESS_EMAIL_VERIFICATION_PLAINTEXT_MESSAGE
+    email_plaintext = api_settings.PASSWORDLESS_EMAIL_VERIFICATION_PLAINTEXT_TEMPLATE_NAME
     email_html = api_settings.PASSWORDLESS_EMAIL_VERIFICATION_TOKEN_HTML_TEMPLATE_NAME
     message_payload = {
         "email_subject": email_subject,


### PR DESCRIPTION
Add plaintext templates for email content equivalent to the existing HTML templates. This makes the additional context available in the plaintext versions of the emails (e.g. host, user email).